### PR TITLE
fix: corrigir formato da versão do Node.js no GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: \"20\" # Use a current LTS version of Node.js
-          cache: \"npm\" # Cache npm dependencies
+          node-version: 20.x # Use a current LTS version of Node.js
+          cache: npm # Cache npm dependencies
 
       - name: Install dependencies
         run: npm ci # Use 'ci' for faster, reliable installs in CI
@@ -28,4 +28,3 @@ jobs:
       - name: Build
         # Use --configuration production for a production build
         run: npm run build -- --configuration production
-


### PR DESCRIPTION
Esta PR corrige o formato da versão do Node.js no arquivo de configuração do GitHub Actions, removendo as aspas duplas que estavam causando erro no build.

Alterações:
- Alterado `node-version: "20"` para `node-version: 20.x`
- Alterado `cache: "npm"` para `cache: npm`